### PR TITLE
SVYX-355 - allow properties to be solution specific

### DIFF
--- a/resources/datasources/svy_security/svy_properties.dbi
+++ b/resources/datasources/svy_security/svy_properties.dbi
@@ -57,6 +57,13 @@ creationOrderIndex:6,
 dataType:12,
 length:500,
 name:"display_name"
+},
+{
+allowNull:true,
+creationOrderIndex:7,
+dataType:12,
+length:50,
+name:"solution_name"
 }
 ],
 name:"svy_properties",

--- a/svyProperties/svyProperties.js
+++ b/svyProperties/svyProperties.js
@@ -357,7 +357,14 @@ function getUserProperty(propertyKey, propertyType) {
 	if (!activeUserName) {
 		throw new Error('No user name set in svyProperties. Make sure a user name is set by calling setUserName().');
 	}
-	return getProperty(propertyKey, propertyType, activeTenantName, activeUserName);
+	var property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName, activeSolutionName);
+	if(!property) {
+		property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName);
+		if(property) {
+			property = setProperty(propertyKey, propertyType, property.getPropertyValue(), activeUserName, activeTenantName, activeSolutionName);
+		}
+	}
+	return property;
 }
 
 /**
@@ -387,7 +394,13 @@ function getUserPropertyValue(propertyKey, propertyType) {
 	if (!activeUserName) {
 		throw new Error('No user name set in svyProperties. Make sure a user name is set by calling setUserName().');
 	}
-	var property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName);
+	var property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName, activeSolutionName);
+	if(!property) {
+		property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName);
+		if(property) {
+			property = setProperty(propertyKey, propertyType, property.getPropertyValue(), activeUserName, activeTenantName, activeSolutionName);
+		}
+	}
 	if (property) {
 		return property.getPropertyValue();
 	} else {
@@ -412,7 +425,14 @@ function getTenantProperty(propertyKey, propertyType) {
 	if (!activeTenantName) {
 		throw new Error('No tenant name set in svyProperties. Make sure a tenant name is set by calling setUserName().');
 	}
-	return getProperty(propertyKey, propertyType, activeTenantName, null);
+	var property = getProperty(propertyKey, propertyType, activeTenantName, null, activeSolutionName);
+	if(!property) {
+		property = getProperty(propertyKey, propertyType, activeTenantName, null);
+		if(property) {
+			property = setProperty(propertyKey, propertyType, property.getPropertyValue(), null, activeTenantName, activeSolutionName);
+		}
+	}
+	return property;
 }
 
 /**
@@ -432,7 +452,13 @@ function getTenantPropertyValue(propertyKey, propertyType) {
 	if (!activeTenantName) {
 		throw new Error('No tenant name set in svyProperties. Make sure a tenant name is set by calling setUserName().');
 	}
-	var property = getProperty(propertyKey, propertyType, activeTenantName, null);
+	var property = getProperty(propertyKey, propertyType, activeTenantName, null, activeSolutionName);
+	if(!property) {
+		property = getProperty(propertyKey, propertyType, activeTenantName, null);
+		if(property) {
+			property = setProperty(propertyKey, propertyType, property.getPropertyValue(), null, activeTenantName, activeSolutionName);
+		}
+	}
 	if (property) {
 		return property.getPropertyValue();
 	} else {
@@ -467,7 +493,7 @@ function getSolutionProperty(propertyKey, propertyType) {
 	if (!activeSolutionName) {
 		throw new Error('No solution name set in svyProperties. Make sure a solution name is set by calling setSolutionName().');
 	}
-	return getProperty(propertyKey, propertyType, activeTenantName, activeUserName, activeSolutionName);
+	return getProperty(propertyKey, propertyType, null, null, activeSolutionName);
 }
 
 /**
@@ -497,7 +523,7 @@ function getSolutionPropertyValue(propertyKey, propertyType) {
 	if (!activeUserName) {
 		throw new Error('No solution name set in svyProperties. Make sure a solution name is set by calling setSolutionName().');
 	}
-	var property = getProperty(propertyKey, propertyType, activeTenantName, activeUserName, activeSolutionName);
+	var property = getProperty(propertyKey, propertyType, null, null, activeSolutionName);
 	if (property) {
 		return property.getPropertyValue();
 	} else {
@@ -628,7 +654,7 @@ function setUserProperty(propertyKey, propertyType, value) {
 	if (!activeUserName) {
 		throw new Error('No user name set in svyProperties. Make sure a user name is set by calling setUserName().');
 	}
-	return setProperty(propertyKey, propertyType, value, activeUserName, activeTenantName);
+	return setProperty(propertyKey, propertyType, value, activeUserName, activeTenantName, activeSolutionName);
 }
 
 /**
@@ -649,7 +675,7 @@ function setTenantProperty(propertyKey, propertyType, value) {
 	if (!activeTenantName) {
 		throw new Error('No tenant name set in svyProperties. Make sure a tenant name is set by calling setUserName().');
 	}
-	return setProperty(propertyKey, propertyType, value, null, activeTenantName);
+	return setProperty(propertyKey, propertyType, value, null, activeTenantName, activeSolutionName);
 }
 
 /**
@@ -670,7 +696,7 @@ function setSolutionProperty(propertyKey, propertyType, value) {
 	if (!activeSolutionName) {
 		throw new Error('No tenant name set in svyProperties. Make sure a tenant name is set by calling setUserName().');
 	}
-	return setProperty(propertyKey, propertyType, value, activeUserName, activeTenantName, activeSolutionName);
+	return setProperty(propertyKey, propertyType, value, null, null, activeSolutionName);
 }
 
 /**


### PR DESCRIPTION
This pull request implements the feature requested in SVYX-355.

The changes will now allow properties to be specified as follows:

1. By user_name, tenant_name and solution_name
2. By tenant_name and solution_name
3. By solution_name
4. Global

The getUserProperty, getUserPropertyValue, getTenantProperty and getTenantPropertyValue methods have been updated so that if a property is requested via these methods and there is no matching record found that includes the solution name, the method will then look for a matching property without a specified solution_name. If this is found then a new property is created that matches the tenant_name and user_name but now with the solution_name added as well and this property is returned. This allows for user and tenant properties that were created prior to this change to be migrated silently in the background and also allows a mix of solutions that both include and exclude this change using the same DB.
